### PR TITLE
Add predefined wind vane ADC values for various platforms

### DIFF
--- a/examples/Example1_BasicReadings/Example1_BasicReadings.ino
+++ b/examples/Example1_BasicReadings/Example1_BasicReadings.ino
@@ -32,10 +32,11 @@ void setup()
     // The platform you're using hasn't been added to the library, so the
     // expected ADC values have been calculated assuming a 10k pullup resistor
     // and a perfectly linear 16-bit ADC. Your ADC likely has a different
-    /// resolution, so you'll need to specify it here
+    // resolution, so you'll need to specify it here:
+    weatherMeterKit.setADCResolutionBits(10);
+    
     Serial.println("Unknown platform! Please edit the code with your ADC resolution!");
     Serial.println();
-    weatherMeterKit.setADCResolutionBits(10);
 #endif
 
     // Begin weather meter kit

--- a/examples/Example1_BasicReadings/Example1_BasicReadings.ino
+++ b/examples/Example1_BasicReadings/Example1_BasicReadings.ino
@@ -25,9 +25,18 @@ void setup()
     Serial.println("for operation, and may not be accurate for your project.");
     Serial.println("It is recommended to check out the calibration examples.");
 
-    // The library assumes a 12-bit ADC, but if yours is different, you can set
-    // the resolution here
-    weatherMeterKit.setADCResolutionBits(12);
+    // Expected ADC values have been defined for various platforms in the
+    // library, however your platform may not be included. This code will check
+    // if that's the case
+#ifdef SFE_WMK_PLAFTORM_UNKNOWN
+    // The platform you're using hasn't been added to the library, so the
+    // expected ADC values have been calculated assuming a 10k pullup resistor
+    // and a perfectly linear 16-bit ADC. Your ADC likely has a different
+    /// resolution, so you'll need to specify it here
+    Serial.println("Unknown platform! Please edit the code with your ADC resolution!");
+    Serial.println();
+    weatherMeterKit.setADCResolutionBits(10);
+#endif
 
     // Begin weather meter kit
     weatherMeterKit.begin();

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun Weather Meter Kit Arduino Library
-version=1.0.0
+version=1.1.0
 author=SparkFun Electronics 
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=A library to use the SparkFun Weather Meter Kit

--- a/src/SparkFun_Weather_Meter_Kit_Arduino_Library.cpp
+++ b/src/SparkFun_Weather_Meter_Kit_Arduino_Library.cpp
@@ -20,44 +20,25 @@ SFEWeatherMeterKit::SFEWeatherMeterKit(uint8_t windDirectionPin, uint8_t windSpe
     _rainfallPin = rainfallPin;
 
     // The wind vane has 8 switches, but 2 could close at the same time, which
-    // results in 16 possible positions. The datasheet specifies the resistance
-    // for each direction, which were used to calculate the expected ADC values
-    // for a 12-bit ADC (4095 max) with a 10k pullup
-    _calibrationParams.vaneADCValues[WMK_ANGLE_0_0] = 3143;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_22_5] = 1624;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_45_0] = 1845;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_67_5] = 335;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_90_0] = 372;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_112_5] = 264;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_135_0] = 738;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_157_5] = 506;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_180_0] = 1149;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_202_5] = 979;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_225_0] = 2520;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_247_5] = 2397;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_270_0] = 3780;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_292_5] = 3309;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_315_0] = 3548;
-    _calibrationParams.vaneADCValues[WMK_ANGLE_337_5] = 2810;
-
-    // The SparkFun Weather Shield Values uses a slightly different circuit, the
-    // expected 12-bit values for it are specified here
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_0_0] = 3610;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_22_5] = 2645;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_45_0] = 2803;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_67_5] = 1560;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_90_0] = 1595;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_112_5] = 1490;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_135_0] = 1932;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_157_5] = 1722;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_180_0] = 2279;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_202_5] = 2139;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_225_0] = 3247;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_247_5] = 3171;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_270_0] = 3943;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_292_5] = 3701;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_315_0] = 3826;
-    // _calibrationParams.vaneADCValues[WMK_ANGLE_337_5] = 3422;
+    // results in 16 possible positions. Each position has a different resistor,
+    // resulting in different ADC values. The expected ADC values has been
+    // experiemntally determined for various platforms, see the constants file
+    _calibrationParams.vaneADCValues[WMK_ANGLE_0_0] = SFE_WMK_ADC_ANGLE_0_0;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_22_5] = SFE_WMK_ADC_ANGLE_22_5;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_45_0] = SFE_WMK_ADC_ANGLE_45_0;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_67_5] = SFE_WMK_ADC_ANGLE_67_5;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_90_0] = SFE_WMK_ADC_ANGLE_90_0;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_112_5] = SFE_WMK_ADC_ANGLE_112_5;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_135_0] = SFE_WMK_ADC_ANGLE_135_0;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_157_5] = SFE_WMK_ADC_ANGLE_157_5;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_180_0] = SFE_WMK_ADC_ANGLE_180_0;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_202_5] = SFE_WMK_ADC_ANGLE_202_5;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_225_0] = SFE_WMK_ADC_ANGLE_225_0;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_247_5] = SFE_WMK_ADC_ANGLE_247_5;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_270_0] = SFE_WMK_ADC_ANGLE_270_0;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_292_5] = SFE_WMK_ADC_ANGLE_292_5;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_315_0] = SFE_WMK_ADC_ANGLE_315_0;
+    _calibrationParams.vaneADCValues[WMK_ANGLE_337_5] = SFE_WMK_ADC_ANGLE_337_5;
 
     // Datasheet specifies 2.4kph of wind causes one trigger per second
     _calibrationParams.kphPerCountPerSec = 2.4;
@@ -120,7 +101,7 @@ void SFEWeatherMeterKit::setADCResolutionBits(uint8_t resolutionBits)
 {
     for(uint8_t i = 0; i < WMK_NUM_ANGLES; i++)
     {
-        int8_t bitShift = (SFE_WIND_VANE_ADC_RESOLUTION_DEFAULT) - resolutionBits;
+        int8_t bitShift = (SFE_WMK_ADC_RESOLUTION) - resolutionBits;
 
         if(bitShift > 0)
         {

--- a/src/SparkFun_Weather_Meter_Kit_Arduino_Library.h
+++ b/src/SparkFun_Weather_Meter_Kit_Arduino_Library.h
@@ -2,31 +2,7 @@
 #define __SPARKFUN_WEATHER_METER_KIT_H__
 
 #include "Arduino.h"
-
-// Enum to define the indexes for each wind direction
-enum SFEWeatherMeterKitAnemometerAngles
-{
-    WMK_ANGLE_0_0 = 0,
-    WMK_ANGLE_22_5,
-    WMK_ANGLE_45_0,
-    WMK_ANGLE_67_5,
-    WMK_ANGLE_90_0,
-    WMK_ANGLE_112_5,
-    WMK_ANGLE_135_0,
-    WMK_ANGLE_157_5,
-    WMK_ANGLE_180_0,
-    WMK_ANGLE_202_5,
-    WMK_ANGLE_225_0,
-    WMK_ANGLE_247_5,
-    WMK_ANGLE_270_0,
-    WMK_ANGLE_292_5,
-    WMK_ANGLE_315_0,
-    WMK_ANGLE_337_5,
-    WMK_NUM_ANGLES
-};
-
-#define SFE_WIND_VANE_DEGREES_PER_INDEX (360.0 / WMK_NUM_ANGLES)
-#define SFE_WIND_VANE_ADC_RESOLUTION_DEFAULT 12
+#include "SparkFun_Weather_Meter_Kit_Constants.h"
 
 // Calibration parameters for each sensor
 struct SFEWeatherMeterKitCalibrationParams

--- a/src/SparkFun_Weather_Meter_Kit_Constants.h
+++ b/src/SparkFun_Weather_Meter_Kit_Constants.h
@@ -1,0 +1,93 @@
+// Enum to define the indexes for each wind direction
+enum SFEWeatherMeterKitAnemometerAngles
+{
+    WMK_ANGLE_0_0 = 0,
+    WMK_ANGLE_22_5,
+    WMK_ANGLE_45_0,
+    WMK_ANGLE_67_5,
+    WMK_ANGLE_90_0,
+    WMK_ANGLE_112_5,
+    WMK_ANGLE_135_0,
+    WMK_ANGLE_157_5,
+    WMK_ANGLE_180_0,
+    WMK_ANGLE_202_5,
+    WMK_ANGLE_225_0,
+    WMK_ANGLE_247_5,
+    WMK_ANGLE_270_0,
+    WMK_ANGLE_292_5,
+    WMK_ANGLE_315_0,
+    WMK_ANGLE_337_5,
+    WMK_NUM_ANGLES
+};
+
+// Angle per index of wind vane (360 / 16 = 22.5)
+#define SFE_WIND_VANE_DEGREES_PER_INDEX (360.0 / WMK_NUM_ANGLES)
+
+// The ADC of each platform behaves slightly differently. Some have different
+// resolutions, some have non-linear outputs, and some voltage divider circuits
+// are different. The expected ADV values have been obtained experimentally for
+// various platforms below
+#ifdef AVR
+    // Tested with RedBoard Qwiic with Weather Shield
+    #define SFE_WMK_ADC_ANGLE_0_0 902
+    #define SFE_WMK_ADC_ANGLE_22_5 661
+    #define SFE_WMK_ADC_ANGLE_45_0 701
+    #define SFE_WMK_ADC_ANGLE_67_5 389
+    #define SFE_WMK_ADC_ANGLE_90_0 398
+    #define SFE_WMK_ADC_ANGLE_112_5 371
+    #define SFE_WMK_ADC_ANGLE_135_0 483
+    #define SFE_WMK_ADC_ANGLE_157_5 430
+    #define SFE_WMK_ADC_ANGLE_180_0 570
+    #define SFE_WMK_ADC_ANGLE_202_5 535
+    #define SFE_WMK_ADC_ANGLE_225_0 812
+    #define SFE_WMK_ADC_ANGLE_247_5 792
+    #define SFE_WMK_ADC_ANGLE_270_0 986
+    #define SFE_WMK_ADC_ANGLE_292_5 925
+    #define SFE_WMK_ADC_ANGLE_315_0 957
+    #define SFE_WMK_ADC_ANGLE_337_5 855
+
+    #define SFE_WMK_ADC_RESOLUTION 10
+#elif ESP32
+    // Tested with ESP32 processor board installed on Weather Carrier
+    #define SFE_WMK_ADC_ANGLE_0_0 3118
+    #define SFE_WMK_ADC_ANGLE_22_5 1526
+    #define SFE_WMK_ADC_ANGLE_45_0 1761
+    #define SFE_WMK_ADC_ANGLE_67_5 199
+    #define SFE_WMK_ADC_ANGLE_90_0 237
+    #define SFE_WMK_ADC_ANGLE_112_5 123
+    #define SFE_WMK_ADC_ANGLE_135_0 613
+    #define SFE_WMK_ADC_ANGLE_157_5 371
+    #define SFE_WMK_ADC_ANGLE_180_0 1040
+    #define SFE_WMK_ADC_ANGLE_202_5 859
+    #define SFE_WMK_ADC_ANGLE_225_0 2451
+    #define SFE_WMK_ADC_ANGLE_247_5 2329
+    #define SFE_WMK_ADC_ANGLE_270_0 3984
+    #define SFE_WMK_ADC_ANGLE_292_5 3290
+    #define SFE_WMK_ADC_ANGLE_315_0 3616
+    #define SFE_WMK_ADC_ANGLE_337_5 2755
+
+    #define SFE_WMK_ADC_RESOLUTION 12
+#else
+    // Values calculated assuming 10k pullup and perfectly linear 16-bit ADC
+    #define SFE_WMK_ADC_ANGLE_0_0 50294
+    #define SFE_WMK_ADC_ANGLE_22_5 25985
+    #define SFE_WMK_ADC_ANGLE_45_0 29527
+    #define SFE_WMK_ADC_ANGLE_67_5 5361
+    #define SFE_WMK_ADC_ANGLE_90_0 5958
+    #define SFE_WMK_ADC_ANGLE_112_5 4219
+    #define SFE_WMK_ADC_ANGLE_135_0 11818
+    #define SFE_WMK_ADC_ANGLE_157_5 8099
+    #define SFE_WMK_ADC_ANGLE_180_0 18388
+    #define SFE_WMK_ADC_ANGLE_202_5 15661
+    #define SFE_WMK_ADC_ANGLE_225_0 40329
+    #define SFE_WMK_ADC_ANGLE_247_5 38365
+    #define SFE_WMK_ADC_ANGLE_270_0 60494
+    #define SFE_WMK_ADC_ANGLE_292_5 52961
+    #define SFE_WMK_ADC_ANGLE_315_0 56785
+    #define SFE_WMK_ADC_ANGLE_337_5 44978
+
+    #define SFE_WMK_ADC_RESOLUTION 16
+
+    // Set macro to indicate that this platform isn't known
+    #define SFE_WMK_PLAFTORM_UNKNOWN
+#endif


### PR DESCRIPTION
Should automatically select ADC values for various platforms. Designed to be expandable as more platforms are added.