### PR TITLE
Halving calibration value for anemometer, according to Chinese text in datasheet

### DIFF
--- a/src/SparkFun_Weather_Meter_Kit_Arduino_Library.cpp
+++ b/src/SparkFun_Weather_Meter_Kit_Arduino_Library.cpp
@@ -40,8 +40,10 @@ SFEWeatherMeterKit::SFEWeatherMeterKit(uint8_t windDirectionPin, uint8_t windSpe
     _calibrationParams.vaneADCValues[WMK_ANGLE_315_0] = SFE_WMK_ADC_ANGLE_315_0;
     _calibrationParams.vaneADCValues[WMK_ANGLE_337_5] = SFE_WMK_ADC_ANGLE_337_5;
 
-    // Datasheet specifies 2.4kph of wind causes one trigger per second
-    _calibrationParams.kphPerCountPerSec = 2.4;
+    // The English text of the datasheet specifies that 2.4 km/h of wind causes
+    // one trigger per second BUT the Chinese text of the datasheet, a value of
+    // 0.33 m/s (corresponding to 1.188 km/h) is reported instead.
+    _calibrationParams.kphPerCountPerSec = 1.188;
 
     // Wind speed sampling interval. Longer durations have more accuracy, but
     // cause delay and can miss fast fluctuations


### PR DESCRIPTION
I suspect that the calibration value for the anemometer is wrong, due to a mistake in the datasheet.

The English text in the datasheet and the Chinese text have two drastically different numbers. The number in English is 2.4 km/h, while in Chinese it is 0.33 m/s, which corresponds to 1.188 km/h, so the half.

I don't own the weather meter kit yet, so I cannot confirm this empirically. Will update this ticket as soon as I own one.

Checking online, I could find a schematics mentioning the halved number [here](https://pop.fsck.pl/hardware/wh-sp-ws01/conn.png) (from [this](https://pop.fsck.pl/hardware/wh-sp-ws01.html) page, or [here](https://web.archive.org/web/20251007145956/https://pop.fsck.pl/hardware/wh-sp-ws01.html) on web archive). The Google-translated text in the image reads: "Wind speed is a passive switch quantity, wind speed sensor. Turn 1 circle, 2 pulses = 2HZ wind speed calculation formula: m/s = wind speed hz * 0,34".

I suppose the error sparks by the fact that each turn of the anemometer causes two clicks in the circuit, not one.

Months ago I wrote an email to the manufacturer (http://foshk.com/) asking for an updated datasheet, but received no answer.